### PR TITLE
Protect against aborted connections

### DIFF
--- a/get
+++ b/get
@@ -1,138 +1,143 @@
 #!/bin/bash
 # wget -O - https://get.hacs.xyz | bash -
-set -e
 
-RED_COLOR='\033[0;31m'
-GREEN_COLOR='\033[0;32m'
-GREEN_YELLOW='\033[1;33m'
-NO_COLOR='\033[0m'
+function run() {
+    set -e
 
-declare haPath
-declare -a paths=(
-    "$PWD"
-    "$PWD/config"
-    "/config"
-    "/homeassistant"
-    "$HOME/.homeassistant"
-    "/usr/share/hassio/homeassistant"
-)
-declare currentVersion
-declare currentYear
-declare currentMonth
-declare currentPatch
-declare targetVersion
-declare targetYear
-declare targetMonth
-declare targetPatch
+    RED_COLOR='\033[0;31m'
+    GREEN_COLOR='\033[0;32m'
+    GREEN_YELLOW='\033[1;33m'
+    NO_COLOR='\033[0m'
 
-function info () { echo -e "${GREEN_COLOR}INFO: $1${NO_COLOR}";}
-function warn () { echo -e "${GREEN_YELLOW}WARN: $1${NO_COLOR}";}
-function error () { echo -e "${RED_COLOR}ERROR: $1${NO_COLOR}"; if [ "$2" != "false" ]; then exit 1;fi; }
+    declare haPath
+    declare -a paths=(
+        "$PWD"
+        "$PWD/config"
+        "/config"
+        "/homeassistant"
+        "$HOME/.homeassistant"
+        "/usr/share/hassio/homeassistant"
+    )
+    declare currentVersion
+    declare currentYear
+    declare currentMonth
+    declare currentPatch
+    declare targetVersion
+    declare targetYear
+    declare targetMonth
+    declare targetPatch
 
-function checkRequirement () {
-    if [ -z "$(command -v "$1")" ]; then
-        error "'$1' is not installed"
-    fi
-}
+    function info () { echo -e "${GREEN_COLOR}INFO: $1${NO_COLOR}";}
+    function warn () { echo -e "${GREEN_YELLOW}WARN: $1${NO_COLOR}";}
+    function error () { echo -e "${RED_COLOR}ERROR: $1${NO_COLOR}"; if [ "$2" != "false" ]; then exit 1;fi; }
 
-checkRequirement "wget"
-checkRequirement "unzip"
+    function checkRequirement () {
+        if [ -z "$(command -v "$1")" ]; then
+            error "'$1' is not installed"
+        fi
+    }
 
-info "Trying to find the correct directory..."
-for path in "${paths[@]}"; do
+    checkRequirement "wget"
+    checkRequirement "unzip"
+
+    info "Trying to find the correct directory..."
+    for path in "${paths[@]}"; do
+        if [ -n "$haPath" ]; then
+            break
+        fi
+
+        if [ -f "$path/.HA_VERSION" ]; then
+            haPath="$path"
+        fi
+    done
+
     if [ -n "$haPath" ]; then
-        break
-    fi
+        info "Found Home Assistant configuration directory at '$haPath'"
+        cd "$haPath" || error "Could not change path to $haPath"
+        if [ ! -d "$haPath/custom_components" ]; then
+            info "Creating custom_components directory..."
+            mkdir "$haPath/custom_components"
+        fi
 
-    if [ -f "$path/.HA_VERSION" ]; then
-        haPath="$path"
-    fi
-done
+        info "Changing to the custom_components directory..."
+        cd "$haPath/custom_components" || error "Could not change path to $haPath/custom_components"
 
-if [ -n "$haPath" ]; then
-    info "Found Home Assistant configuration directory at '$haPath'"
-    cd "$haPath" || error "Could not change path to $haPath"
-    if [ ! -d "$haPath/custom_components" ]; then
-        info "Creating custom_components directory..."
-        mkdir "$haPath/custom_components"
-    fi
-
-    info "Changing to the custom_components directory..."
-    cd "$haPath/custom_components" || error "Could not change path to $haPath/custom_components"
-
-    info "Downloading HACS"
-    rm -f "$haPath/custom_components/hacs.zip"
-    wget "https://github.com/hacs/integration/releases/latest/download/hacs.zip"
-
-    if [ -d "$haPath/custom_components/hacs" ]; then
-        warn "HACS directory already exist, cleaning up..."
-        rm -R "$haPath/custom_components/hacs"
-    fi
-
-    info "Creating HACS directory..."
-    mkdir "$haPath/custom_components/hacs"
-
-    info "Unpacking HACS..."
-    unzip "$haPath/custom_components/hacs.zip" -d "$haPath/custom_components/hacs" >/dev/null 2>&1
-
-
-    echo
-    info "Verifying versions"
-    targetVersion=$(sed -n -e '/^MINIMUM_HA_VERSION/p' "$haPath/custom_components/hacs/const.py" | cut -d '"' -f 2)
-    currentVersion=$(cat "$haPath/.HA_VERSION")
-
-    info "Current version is ${currentVersion}, minimum version is ${targetVersion}"
-
-    targetYear=$(echo "${targetVersion}" | cut -d "." -f 1)
-    currentYear=$(echo "${currentVersion}" | cut -d "." -f 1)
-
-    if [ "${currentVersion}" == "2023.12.0" ]; then
-        rm -R "$haPath/custom_components/hacs"
+        info "Downloading HACS"
         rm -f "$haPath/custom_components/hacs.zip"
-        error "HACS will not work on version 2023.12.0 of Home Assistant, upgrade to 2023.12.1 (or newer) before re-running this script."
-    fi
+        wget "https://github.com/hacs/integration/releases/latest/download/hacs.zip"
 
-    if [ "${currentYear}" -lt "${targetYear}" ]; then
-        rm -R "$haPath/custom_components/hacs"
-        rm -f "$haPath/custom_components/hacs.zip"
-        error "Version ${currentVersion} is not new enough, needs at least ${targetVersion}"
-    fi
+        if [ -d "$haPath/custom_components/hacs" ]; then
+            warn "HACS directory already exist, cleaning up..."
+            rm -R "$haPath/custom_components/hacs"
+        fi
+
+        info "Creating HACS directory..."
+        mkdir "$haPath/custom_components/hacs"
+
+        info "Unpacking HACS..."
+        unzip "$haPath/custom_components/hacs.zip" -d "$haPath/custom_components/hacs" >/dev/null 2>&1
 
 
-    if [ "${currentYear}" == "${targetYear}" ]; then
-        targetMonth=$(echo "${targetVersion}" | cut -d "." -f 2)
-        currentMonth=$(echo "${currentVersion}" | cut -d "." -f 2)
+        echo
+        info "Verifying versions"
+        targetVersion=$(sed -n -e '/^MINIMUM_HA_VERSION/p' "$haPath/custom_components/hacs/const.py" | cut -d '"' -f 2)
+        currentVersion=$(cat "$haPath/.HA_VERSION")
 
-        if [ "${currentMonth}" -lt "${targetMonth}" ]; then
+        info "Current version is ${currentVersion}, minimum version is ${targetVersion}"
+
+        targetYear=$(echo "${targetVersion}" | cut -d "." -f 1)
+        currentYear=$(echo "${currentVersion}" | cut -d "." -f 1)
+
+        if [ "${currentVersion}" == "2023.12.0" ]; then
+            rm -R "$haPath/custom_components/hacs"
+            rm -f "$haPath/custom_components/hacs.zip"
+            error "HACS will not work on version 2023.12.0 of Home Assistant, upgrade to 2023.12.1 (or newer) before re-running this script."
+        fi
+
+        if [ "${currentYear}" -lt "${targetYear}" ]; then
             rm -R "$haPath/custom_components/hacs"
             rm -f "$haPath/custom_components/hacs.zip"
             error "Version ${currentVersion} is not new enough, needs at least ${targetVersion}"
         fi
 
-        if [ "${currentMonth}" == "${targetMonth}" ]; then
-            targetPatch=$(echo "${targetVersion}" | cut -d "." -f 3)
-            currentPatch=$(echo "${currentVersion}" | cut -d "." -f 3)
 
-            if [ "${currentPatch}" -lt "${targetPatch}" ]; then
+        if [ "${currentYear}" == "${targetYear}" ]; then
+            targetMonth=$(echo "${targetVersion}" | cut -d "." -f 2)
+            currentMonth=$(echo "${currentVersion}" | cut -d "." -f 2)
+
+            if [ "${currentMonth}" -lt "${targetMonth}" ]; then
                 rm -R "$haPath/custom_components/hacs"
                 rm -f "$haPath/custom_components/hacs.zip"
                 error "Version ${currentVersion} is not new enough, needs at least ${targetVersion}"
             fi
+
+            if [ "${currentMonth}" == "${targetMonth}" ]; then
+                targetPatch=$(echo "${targetVersion}" | cut -d "." -f 3)
+                currentPatch=$(echo "${currentVersion}" | cut -d "." -f 3)
+
+                if [ "${currentPatch}" -lt "${targetPatch}" ]; then
+                    rm -R "$haPath/custom_components/hacs"
+                    rm -f "$haPath/custom_components/hacs.zip"
+                    error "Version ${currentVersion} is not new enough, needs at least ${targetVersion}"
+                fi
+            fi
         fi
+
+        echo
+        info "Removing HACS zip file..."
+        rm -f "$haPath/custom_components/hacs.zip"
+        info "Installation complete."
+        echo
+        info "Remember to restart Home Assistant before you configure it"
+
+    else
+        echo
+        error "Could not find the directory for Home Assistant" false
+        echo "Manually change the directory to the root of your Home Assistant configuration"
+        echo "With the user that is running Home Assistant"
+        echo "and run the script again"
+        exit 1
     fi
+}
 
-    echo
-    info "Removing HACS zip file..."
-    rm -f "$haPath/custom_components/hacs.zip"
-    info "Installation complete."
-    echo
-    info "Remember to restart Home Assistant before you configure it"
-
-else
-    echo
-    error "Could not find the directory for Home Assistant" false
-    echo "Manually change the directory to the root of your Home Assistant configuration"
-    echo "With the user that is running Home Assistant"
-    echo "and run the script again"
-    exit 1
-fi
+run


### PR DESCRIPTION
Best practice when doing `curl | bash` (or `curl | any_interpreter` really) is to wrap all your actual logic into a function which is executed only at the end of the script. The reason is because otherwise, if the connection is aborted partway, then the script will have half-run.

I did not test this, but it looks like y'all have CI? And the change is trivial anyway (I did `sed -i 's/^/    /' get` to make the whitespace changes, wrapped the result in a function declaration, and then did `sed -Ei 's/^[[:space:]]+$//' get` because I realized my first `sed` invocation messed with empty lines as well).