### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,18 @@
 version: 2
 updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    labels:
+      - "pr: dependency-update"
+    schedule:
+      interval: weekly
+      time: "06:00"
+    open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
+    labels:
+      - "pr: dependency-update"
     schedule:
-      interval: daily
+      interval: weekly
       time: "06:00"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Add devcontainer features as well (not sure if it will work without a pinned version)
and change interval to weekly in line with other dependabot configs.

Not sure if we want label `dependency-update` as other repos or `dependencies` as has been used till now.